### PR TITLE
Remove double typisation for IResponse.result

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.0-rc4",
+  "version": "1.0.0-rc5",
   "description": "the referencable contracts for http",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
   "contributors": [
     "Sebastian Meier <sebastian.meier@5minds.de>",
+    "Christian Werner <christian.werner@5minds.de>",
     "Patrick Pötschke <patrick.poetschke@quantusflow.com>",
     "Simon Reymann <simon.reymann@quantusflow.com>"
   ],

--- a/src/iresponse.ts
+++ b/src/iresponse.ts
@@ -1,4 +1,4 @@
 export interface IResponse<T> {
-  result: T | Array<T>;
+  result: T;
   status: number;
 }


### PR DESCRIPTION
## What did you change?

Remove doubled typification for the IResponse.result property.
This typing hat the effect that it made explicit typecasting necessary, when using the http client to make http requests.
This was discovered during the implementation of the consumer_api_client.

The current implementation required functions such as this to avoid TSLint errors:
```
  public async getProcessModels(): Promise<IProcessModelList> {
    const httpResponse: IResponse<IProcessModelList> = await this.httpClient.get<IProcessModelList>(routes.processModels);

    return <IProcessModelList> httpResponse.result;
  }
``` 

With this PR, the following is possible:
```
    return httpResponse.result;
```

## How can others test the changes?

- Implement this version of the http_contracts module in any project that makes use of the httpClient or the httpService from `@essential-project/services`
- Paste a function like the following (Replace `T` with whatever type suits your use case):
```
  public async getProcessModels(): Promise<T> {
    const httpResponse: IResponse<T> = await this.httpClient.get<T>('some/route');

    return httpResponse.result;
  }
```
- See that TSLint does not complain about an invalid signature for the return parameter.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
