### PR TITLE
✨Add deprecation warning middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "the referencable contracts for http",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,7 @@
+import {NextFunction, Response} from 'express';
+
+import {HttpRequestWithIdentity} from './http_request_with_identity';
+
 export const defaultSocketNamespace = '/default';
+
+export type MiddlewareFunction = (request: HttpRequestWithIdentity, response: Response, next: NextFunction) => void | Promise<void>;

--- a/src/depcreation_warning_middleware.ts
+++ b/src/depcreation_warning_middleware.ts
@@ -1,0 +1,40 @@
+import {NextFunction, Response} from 'express';
+import {Logger} from 'loggerhythm';
+
+import {MiddlewareFunction} from './constants';
+import {HttpRequestWithIdentity} from './http_request_with_identity';
+
+const logger = Logger.createLogger('essentialprojects:http:deprecation_notifier');
+
+/**
+ * Allows you to mark a route as deprecated.
+ *
+ * Usage:
+ *
+ * Without an alternative route:
+ * router.post('/my/depcreated/route', deprecate(), requestHandlerFunction);
+ *
+ * With an alternative route:
+ * router.post('/my/depcreated/route', deprecate('/my/alternative/route'), requestHandlerFunction);
+ *
+ * @param alternativeRoute Optional: A replacement route that the user can use as an alternative.
+ */
+export function deprecate(alternativeRoute?: string): MiddlewareFunction {
+
+  return (request: HttpRequestWithIdentity, response: Response, next: NextFunction): void => {
+
+    let deprecatedRoute = request.originalUrl;
+
+    for (const paramName of Object.keys(request.params)) {
+      deprecatedRoute = deprecatedRoute.replace(request.params[paramName], `:${paramName}`);
+    }
+
+    logger.warn(`Route '${deprecatedRoute}' has been depcreated an will be removed in an upcoming major release!`);
+
+    if (alternativeRoute) {
+      logger.warn(`Use '${alternativeRoute}' instead!`);
+    }
+
+    return next();
+  };
+}

--- a/src/depcreation_warning_middleware.ts
+++ b/src/depcreation_warning_middleware.ts
@@ -29,9 +29,14 @@ export function deprecate(alternativeRoute?: string): MiddlewareFunction {
       deprecatedRoute = deprecatedRoute.replace(request.params[paramName], `:${paramName}`);
     }
 
+    // See: https://tools.ietf.org/id/draft-dalal-deprecation-header-01.html
+    response.setHeader('Deprecation', 'true');
+
     logger.warn(`Route '${deprecatedRoute}' has been depcreated an will be removed in an upcoming major release!`);
 
     if (alternativeRoute) {
+      // See: https://tools.ietf.org/id/draft-dalal-deprecation-header-01.html#recommend-replacement
+      response.setHeader('Link', alternativeRoute);
       logger.warn(`Use '${alternativeRoute}' instead!`);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './constants';
+export * from './depcreation_warning_middleware';
 export * from './http_request_with_identity';
 export * from './ihttp_client';
 export * from './ihttp_extension';

--- a/src/resolve_identity_middleware.ts
+++ b/src/resolve_identity_middleware.ts
@@ -3,11 +3,11 @@ import {Logger} from 'loggerhythm';
 
 import {BadRequestError, UnauthorizedError} from '@essential-projects/errors_ts';
 import {IIdentityService} from '@essential-projects/iam_contracts';
+
+import {MiddlewareFunction} from './constants';
 import {HttpRequestWithIdentity} from './http_request_with_identity';
 
-const logger = Logger.createLogger('processengine:consumer_api:resolve_identity_middleware');
-
-export type MiddlewareFunction = (request: HttpRequestWithIdentity, response: Response, next: NextFunction) => Promise<void>;
+const logger = Logger.createLogger('essentialprojects:http:identity_resolver');
 
 export function createResolveIdentityMiddleware(identityService: IIdentityService): MiddlewareFunction {
 


### PR DESCRIPTION
## Changes
 
1. Move `MiddlewareFunction` type to `constants.ts`
2. Support sync functions for `MiddlewareFunction` in addition to Promise-based functions
3.  Add `deprecate` middleware 
    - Prints out a warning on the console, informing the user that the route is deprecated
    - Also sets the `Deprecated` and `Link` Http Response headers
4. Fix logger namespace for `resolveIdentity` middleware

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/533

PR: #1

## How to test the changes

See https://github.com/process-engine/consumer_api_http/compare/feature/mark_external_task_routes_as_deprecated